### PR TITLE
Add support for dgram icmp sockets

### DIFF
--- a/lib/AnyEvent/Ping.pm
+++ b/lib/AnyEvent/Ping.pm
@@ -195,7 +195,7 @@ sub _on_read {
     if ($self->{socket_type} eq 'dgram' && $^O eq 'linux') {
         # with a dgram socket under linux, the indentifier is rewritten by the
         # kernel, so we match via the random data in the packet instead.
-        $request = List::Util::first { $data == $_->{data} } @{$self->{_tasks}};
+        $request = List::Util::first { $data eq $_->{data} } @{$self->{_tasks}};
     }
     else {
         $request = List::Util::first { $identifier == $_->{identifier} } @{$self->{_tasks}};

--- a/lib/AnyEvent/Ping.pm
+++ b/lib/AnyEvent/Ping.pm
@@ -429,6 +429,22 @@ combined with the 8 bytes of ICMP header data.
 Each packet will be generated with generate_data_random() like this:
 
     &AnyEvent::Ping::generate_data_random($packet_size);
+    
+=head3 C<socket_type>
+
+Default to C<raw>, but can also be C<dgram>.  When dgram is set, a datagram ICMP
+socket is created.  This is an extension implemented in Linux and Mac OS X
+allowing ping ICMP messages to be sent while not root.
+
+Under linux, you will need to whitelist a group that your pinging code is running
+under.  The relevent sysctl takes a range of groups:
+
+   echo '0 2000' > /proc/sys/net/ipv4/ping_group_range
+   
+or to make it last between reboots:
+
+   echo "net.ipv4.ping_group_range=0 2000" > /etc/sysctl.d/60-icmp-ping.conf
+   /etc/init.d/procps restart
 
 =head2 C<ping>
 

--- a/t/dgram.t
+++ b/t/dgram.t
@@ -8,13 +8,13 @@ use AnyEvent;
 
 # TODO: determinate local address and broadcast address
 
-plan skip_all => 'You can run tests just as root' if $<;
 
 use_ok 'AnyEvent::Ping';
 
 my $ping = new_ok 'AnyEvent::Ping' => [
-    timeout    => 1,
-    on_prepare => \&on_prepare
+    timeout     => 1,
+    on_prepare  => \&on_prepare,
+    socket_type => 'dgram',
 ];
 
 subtest 'ping 127.0.0.1' => sub {
@@ -40,6 +40,7 @@ subtest 'ping 127.0.0.1' => sub {
 
     done_testing;
 };
+
 
 subtest 'check two concurrent ping' => sub {
     my $cv = AnyEvent->condvar;
@@ -93,7 +94,7 @@ subtest 'ping broadcast' => sub {
 };
 
 subtest 'force end' => sub {
-    my $ping = new_ok 'AnyEvent::Ping';
+    my $ping = new_ok 'AnyEvent::Ping' => [socket_type => 'dgram'];
     my $cv = AnyEvent->condvar;
 
     my $long_times = 1000;


### PR DESCRIPTION
Linux and OS X now support an extension that allows non-root users to ping via dgram icmp sockets.  This changeset adds a socket_type option which lets AnyEvent::Ping use dgram sockets.